### PR TITLE
Build out Dictionary/Terms area

### DIFF
--- a/app/assets/images/icon-book.svg
+++ b/app/assets/images/icon-book.svg
@@ -1,0 +1,232 @@
+<svg width="30" height="37" viewBox="0 0 30 37" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_di_45_21380)">
+<path d="M23.1262 2.88773L5.13637 6.59332C4.84434 6.65348 4.69832 6.68355 4.5962 6.7641C4.51369 6.82917 4.45156 6.91654 4.41717 7.01583C4.37461 7.13874 4.39412 7.28654 4.43315 7.58213L7.67356 32.1227C7.71185 32.4127 7.73099 32.5577 7.80225 32.6642C7.85984 32.7504 7.94059 32.8184 8.0352 32.8607C8.15225 32.9129 8.29839 32.9073 8.59067 32.896L8.59069 32.896L26.9764 32.1884C27.3221 32.175 27.495 32.1684 27.6183 32.0921C27.7176 32.0306 27.7948 31.9391 27.8386 31.8308C27.893 31.6964 27.8703 31.5249 27.825 31.1819L24.1888 3.64339C24.1443 3.30677 24.1221 3.13846 24.0366 3.02375C23.9677 2.93129 23.8714 2.86284 23.7615 2.82809C23.6251 2.78498 23.4588 2.81923 23.1262 2.88773Z" fill="#8459D1"/>
+<path d="M23.9292 2.90845C23.9292 2.90845 24.0421 2.98982 24.0898 3.09846C24.1289 3.18744 24.1315 3.21552 24.1323 3.21474L27.8793 31.5922C27.8793 31.5922 27.8801 31.6763 27.8703 31.7289C27.8516 31.829 27.7663 31.9681 27.7663 31.9681L23.9292 2.90845Z" fill="url(#paint0_linear_45_21380)"/>
+<path d="M23.9292 2.90845C23.9292 2.90845 24.0421 2.98982 24.0898 3.09846C24.1289 3.18744 24.1315 3.21552 24.1323 3.21474L27.8793 31.5922C27.8793 31.5922 27.8801 31.6763 27.8703 31.7289C27.8516 31.829 27.7663 31.9681 27.7663 31.9681L23.9292 2.90845Z" fill="url(#paint1_linear_45_21380)"/>
+<g filter="url(#filter1_d_45_21380)">
+<path d="M23.6592 3.37879L4.71547 7.28086L8.03141 32.3935L27.392 31.6483L23.6592 3.37879Z" fill="white"/>
+<path d="M23.6592 3.37879L4.71547 7.28086L8.03141 32.3935L27.392 31.6483L23.6592 3.37879Z" stroke="#CBCBCB" stroke-width="0.0559647"/>
+</g>
+<g filter="url(#filter2_d_45_21380)">
+<path d="M23.5467 3.32248L4.63851 7.22504L7.96673 32.4307L27.2933 31.6967L23.5467 3.32248Z" fill="white"/>
+<path d="M23.5467 3.32248L4.63851 7.22504L7.96673 32.4307L27.2933 31.6967L23.5467 3.32248Z" stroke="#CBCBCB" stroke-width="0.0559647"/>
+</g>
+<g filter="url(#filter3_d_45_21380)">
+<path d="M23.4358 3.30137L4.52834 7.20902L7.86884 32.5076L27.1963 31.7802L23.4358 3.30137Z" fill="white"/>
+<path d="M23.4358 3.30137L4.52834 7.20902L7.86884 32.5076L27.1963 31.7802L23.4358 3.30137Z" stroke="#CBCBCB" stroke-width="0.0559647"/>
+</g>
+<g filter="url(#filter4_d_45_21380)">
+<path d="M23.3221 3.24534L4.41525 7.15809L7.76803 32.5497L27.0963 31.8289L23.3221 3.24534Z" fill="white"/>
+<path d="M23.3221 3.24534L4.41525 7.15809L7.76803 32.5497L27.0963 31.8289L23.3221 3.24534Z" stroke="#CBCBCB" stroke-width="0.0559647"/>
+</g>
+<g filter="url(#filter5_d_45_21380)">
+<path d="M23.2132 3.22422L4.30703 7.14207L7.67209 32.6267L27.0013 31.9125L23.2132 3.22422Z" fill="white"/>
+<path d="M23.2132 3.22422L4.30703 7.14207L7.67209 32.6267L27.0013 31.9125L23.2132 3.22422Z" stroke="#CBCBCB" stroke-width="0.0559647"/>
+</g>
+<g filter="url(#filter6_d_45_21380)">
+<path d="M23.0992 3.16822L4.29888 7.08075L7.68441 32.7204L26.9103 32.031L23.0992 3.16822Z" fill="white"/>
+<path d="M23.0992 3.16822L4.29888 7.08075L7.68441 32.7204L26.9103 32.031L23.0992 3.16822Z" stroke="#CBCBCB" stroke-width="0.0559647"/>
+</g>
+<g filter="url(#filter7_d_45_21380)">
+<path d="M22.9903 3.1471L4.19089 7.06643L7.59279 32.8301L26.8199 32.1495L22.9903 3.1471Z" fill="white"/>
+<path d="M22.9903 3.1471L4.19089 7.06643L7.59279 32.8301L26.8199 32.1495L22.9903 3.1471Z" stroke="#CBCBCB" stroke-width="0.0559647"/>
+</g>
+<g filter="url(#filter8_d_45_21380)">
+<path d="M22.8717 3.05604L4.07358 6.98556L7.50005 32.9352L26.7289 32.2678L22.8717 3.05604Z" fill="white"/>
+<path d="M22.8717 3.05604L4.07358 6.98556L7.50005 32.9352L26.7289 32.2678L22.8717 3.05604Z" stroke="#CBCBCB" stroke-width="0.0559647"/>
+</g>
+<g filter="url(#filter9_d_45_21380)">
+<path d="M22.7579 3.00086L3.96094 6.93888L7.40787 33.0436L26.6381 32.3872L22.7579 3.00086Z" fill="white"/>
+<path d="M22.7579 3.00086L3.96094 6.93888L7.40787 33.0436L26.6381 32.3872L22.7579 3.00086Z" stroke="#CBCBCB" stroke-width="0.0559647"/>
+</g>
+<g filter="url(#filter10_d_45_21380)">
+<path d="M22.6392 2.9098L3.84408 6.86142L7.32376 33.2141L26.5563 32.5753L22.6392 2.9098Z" fill="white"/>
+<path d="M22.6392 2.9098L3.84408 6.86142L7.32376 33.2141L26.5563 32.5753L22.6392 2.9098Z" stroke="#CBCBCB" stroke-width="0.0559647"/>
+</g>
+<g filter="url(#filter11_d_45_21380)">
+<path d="M22.5206 2.81885L3.72677 6.78067L7.23102 33.3194L26.4653 32.6938L22.5206 2.81885Z" fill="white"/>
+<path d="M22.5206 2.81885L3.72677 6.78067L7.23102 33.3194L26.4653 32.6938L22.5206 2.81885Z" stroke="#CBCBCB" stroke-width="0.0559647"/>
+</g>
+<g filter="url(#filter12_d_45_21380)">
+<path d="M22.4019 2.72706L3.60969 6.70077L7.14259 33.4565L26.379 32.8463L22.4019 2.72706Z" fill="white"/>
+<path d="M22.4019 2.72706L3.60969 6.70077L7.14259 33.4565L26.379 32.8463L22.4019 2.72706Z" stroke="#CBCBCB" stroke-width="0.0559647"/>
+</g>
+<g filter="url(#filter13_d_45_21380)">
+<path d="M22.2833 2.63685L3.49239 6.62076L7.04985 33.5625L26.288 32.9655L22.2833 2.63685Z" fill="white"/>
+<path d="M22.2833 2.63685L3.49239 6.62076L7.04985 33.5625L26.288 32.9655L22.2833 2.63685Z" stroke="#CBCBCB" stroke-width="0.0559647"/>
+</g>
+<path d="M21.0657 2.18087L3.50023 5.90011L3.50023 5.90011C3.02773 6.00015 2.79148 6.05018 2.6671 6.2261C2.54272 6.40202 2.57433 6.64143 2.63756 7.12025L6.09522 33.3062C6.15714 33.7752 6.1881 34.0096 6.3496 34.1468C6.5111 34.2839 6.74749 34.2765 7.22026 34.2617L25.2023 33.6974C25.7701 33.6796 26.0539 33.6707 26.2119 33.4847C26.3699 33.2986 26.3327 33.0171 26.2584 32.454L22.3841 3.11301C22.3113 2.56135 22.2749 2.28552 22.0786 2.14675C21.8823 2.00797 21.6101 2.0656 21.0657 2.18087Z" fill="#6927DA"/>
+<path d="M21.0657 2.18087L3.50023 5.90011L3.50023 5.90011C3.02773 6.00015 2.79148 6.05018 2.6671 6.2261C2.54272 6.40202 2.57433 6.64143 2.63756 7.12025L6.09522 33.3062C6.15714 33.7752 6.1881 34.0096 6.3496 34.1468C6.5111 34.2839 6.74749 34.2765 7.22026 34.2617L25.2023 33.6974C25.7701 33.6796 26.0539 33.6707 26.2119 33.4847C26.3699 33.2986 26.3327 33.0171 26.2584 32.454L22.3841 3.11301C22.3113 2.56135 22.2749 2.28552 22.0786 2.14675C21.8823 2.00797 21.6101 2.0656 21.0657 2.18087Z" fill="url(#paint2_linear_45_21380)"/>
+<path d="M21.8687 2.05066C21.8687 2.05066 22.1034 2.11074 22.1982 2.22192C22.2758 2.31297 22.3168 2.50248 22.3188 2.50149L26.3563 33.0788C26.3563 33.0788 26.3403 33.3215 26.2888 33.413C26.2228 33.5302 26.0392 33.6357 26.0392 33.6357L21.8687 2.05066Z" fill="url(#paint3_linear_45_21380)"/>
+<path d="M21.8687 2.05066C21.8687 2.05066 22.1034 2.11074 22.1982 2.22192C22.2758 2.31297 22.3168 2.50248 22.3188 2.50149L26.3563 33.0788C26.3563 33.0788 26.3403 33.3215 26.2888 33.413C26.2228 33.5302 26.0392 33.6357 26.0392 33.6357L21.8687 2.05066Z" fill="url(#paint4_linear_45_21380)"/>
+</g>
+<defs>
+<filter id="filter0_di_45_21380" x="0.300293" y="-0.290649" width="29.8228" height="38.5812" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.06 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_45_21380"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_45_21380" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.05 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_45_21380"/>
+</filter>
+<filter id="filter1_d_45_21380" x="4.62812" y="3.23341" width="22.9636" height="29.3009" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.0559647"/>
+<feGaussianBlur stdDeviation="0.0559647"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_45_21380"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_45_21380" result="shape"/>
+</filter>
+<filter id="filter2_d_45_21380" x="4.55146" y="3.17701" width="22.9416" height="29.3945" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.0559647"/>
+<feGaussianBlur stdDeviation="0.0559647"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_45_21380"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_45_21380" result="shape"/>
+</filter>
+<filter id="filter3_d_45_21380" x="4.44111" y="3.15589" width="22.9548" height="29.4927" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.0559647"/>
+<feGaussianBlur stdDeviation="0.0559647"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_45_21380"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_45_21380" result="shape"/>
+</filter>
+<filter id="filter4_d_45_21380" x="4.32831" y="3.09986" width="22.9675" height="29.5907" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.0559647"/>
+<feGaussianBlur stdDeviation="0.0559647"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_45_21380"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_45_21380" result="shape"/>
+</filter>
+<filter id="filter5_d_45_21380" x="4.21991" y="3.07874" width="22.9812" height="29.6888" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.0559647"/>
+<feGaussianBlur stdDeviation="0.0559647"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_45_21380"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_45_21380" result="shape"/>
+</filter>
+<filter id="filter6_d_45_21380" x="4.21161" y="3.02271" width="22.8982" height="29.8385" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.0559647"/>
+<feGaussianBlur stdDeviation="0.0559647"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_45_21380"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_45_21380" result="shape"/>
+</filter>
+<filter id="filter7_d_45_21380" x="4.1037" y="3.0016" width="22.9158" height="29.9693" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.0559647"/>
+<feGaussianBlur stdDeviation="0.0559647"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_45_21380"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_45_21380" result="shape"/>
+</filter>
+<filter id="filter8_d_45_21380" x="3.98652" y="2.91053" width="22.9421" height="30.1655" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.0559647"/>
+<feGaussianBlur stdDeviation="0.0559647"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_45_21380"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_45_21380" result="shape"/>
+</filter>
+<filter id="filter9_d_45_21380" x="3.87372" y="2.85536" width="22.9641" height="30.329" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.0559647"/>
+<feGaussianBlur stdDeviation="0.0559647"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_45_21380"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_45_21380" result="shape"/>
+</filter>
+<filter id="filter10_d_45_21380" x="3.75702" y="2.76429" width="22.9988" height="30.5906" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.0559647"/>
+<feGaussianBlur stdDeviation="0.0559647"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_45_21380"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_45_21380" result="shape"/>
+</filter>
+<filter id="filter11_d_45_21380" x="3.63984" y="2.67335" width="23.0251" height="30.7868" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.0559647"/>
+<feGaussianBlur stdDeviation="0.0559647"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_45_21380"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_45_21380" result="shape"/>
+</filter>
+<filter id="filter12_d_45_21380" x="3.52265" y="2.58155" width="23.0559" height="31.0157" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.0559647"/>
+<feGaussianBlur stdDeviation="0.0559647"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_45_21380"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_45_21380" result="shape"/>
+</filter>
+<filter id="filter13_d_45_21380" x="3.40546" y="2.49122" width="23.0823" height="31.212" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.0559647"/>
+<feGaussianBlur stdDeviation="0.0559647"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_45_21380"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_45_21380" result="shape"/>
+</filter>
+<linearGradient id="paint0_linear_45_21380" x1="25.89" y1="17.7578" x2="26.0422" y2="17.7377" gradientUnits="userSpaceOnUse">
+<stop stop-color="#7044BF"/>
+<stop offset="1" stop-color="#A97EF5"/>
+</linearGradient>
+<linearGradient id="paint1_linear_45_21380" x1="23.9972" y1="2.71947" x2="24.5034" y2="2.6612" gradientUnits="userSpaceOnUse">
+<stop stop-color="#AC7DFF" stop-opacity="0"/>
+<stop offset="1" stop-color="#562D9D" stop-opacity="0.65"/>
+</linearGradient>
+<linearGradient id="paint2_linear_45_21380" x1="14.0478" y1="1.70937" x2="16.0095" y2="33.4063" gradientUnits="userSpaceOnUse">
+<stop stop-color="#B388FF" stop-opacity="0.5"/>
+<stop offset="1" stop-color="#673AB7"/>
+<stop offset="1" stop-color="#5C00FF"/>
+</linearGradient>
+<linearGradient id="paint3_linear_45_21380" x1="23.9984" y1="18.1803" x2="24.3641" y2="18.132" gradientUnits="userSpaceOnUse">
+<stop stop-color="#A97EF5"/>
+<stop offset="1" stop-color="#7044BF"/>
+</linearGradient>
+<linearGradient id="paint4_linear_45_21380" x1="22.0826" y1="1.9805" x2="23.3003" y2="1.86558" gradientUnits="userSpaceOnUse">
+<stop stop-color="#AC7DFF" stop-opacity="0"/>
+<stop offset="1" stop-color="#562D9D" stop-opacity="0.65"/>
+</linearGradient>
+</defs>
+</svg>

--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -1,7 +1,12 @@
 class TermsController < ApplicationController
   def index
+    @query = params[:q]
+
+    @terms = Term.all
+    @terms = @terms.where("title ILIKE ?", "%#{@query}%") if @query.present?
   end
 
   def show
+    @term = Term.find(params[:id])
   end
 end

--- a/app/helpers/terms_helper.rb
+++ b/app/helpers/terms_helper.rb
@@ -1,2 +1,30 @@
 module TermsHelper
+  def dict_groups
+    [
+      "#",
+      "A - B",
+      "C - D",
+      "E - F",
+      "G - H",
+      "I - J",
+      "K - L",
+      "M - N",
+      "O - P",
+      "Q - R",
+      "S - T",
+      "U - V",
+      "W - X",
+      "Y - Z"
+    ]
+  end
+
+  def dict_group(title)
+    first_char = title[0]&.upcase
+
+    return "#" unless first_char.match?(/[A-Z]/)
+
+    group_index = (first_char.ord - "A".ord) / 2
+
+    dict_groups[group_index + 1]
+  end
 end

--- a/app/javascript/controllers/auto_submit_form_controller.js
+++ b/app/javascript/controllers/auto_submit_form_controller.js
@@ -1,0 +1,33 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  // By default, auto-submit is "opt-in" to avoid unexpected behavior.  Each `auto` target
+  // will trigger a form submission when the configured event is triggered.
+  static targets = ["auto"];
+  static values = {
+    triggerEvent: { type: String, default: "input" },
+  };
+
+  connect() {
+    this.autoTargets.forEach((element) => {
+      const event =
+        element.dataset.autosubmitTriggerEvent || this.triggerEventValue;
+      element.addEventListener(event, this.handleInput);
+    });
+  }
+
+  disconnect() {
+    this.autoTargets.forEach((element) => {
+      const event =
+        element.dataset.autosubmitTriggerEvent || this.triggerEventValue;
+      element.removeEventListener(event, this.handleInput);
+    });
+  }
+
+  handleInput = () => {
+    clearTimeout(this.timeout);
+    this.timeout = setTimeout(() => {
+      this.element.requestSubmit();
+    }, 500);
+  };
+}

--- a/app/javascript/controllers/section_links_controller.js
+++ b/app/javascript/controllers/section_links_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["section", "link"];
+  static classes = ["active"];
+
+  connect() {
+    this.updateActiveLink();
+    window.addEventListener("scroll", () => this.updateActiveLink());
+  }
+
+  disconnect() {
+    window.removeEventListener("scroll", () => this.updateActiveLink());
+  }
+
+  updateActiveLink() {
+    let currentSectionId = "";
+
+    this.sectionTargets.forEach((section) => {
+      const sectionTop = section.offsetTop;
+      const sectionHeight = section.clientHeight;
+
+      if (window.scrollY >= sectionTop - sectionHeight / 3) {
+        currentSectionId = section.getAttribute("id");
+      }
+    });
+
+    currentSectionId = currentSectionId || "#";
+
+    this.linkTargets.forEach((link) => {
+      link.classList.remove(...this.activeClasses);
+
+      if (link.getAttribute("href").slice(1).includes(currentSectionId)) {
+        link.classList.add(...this.activeClasses);
+      }
+    });
+  }
+}

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -1,2 +1,5 @@
 class Term < ApplicationRecord
+  def self.random_sample(count, exclude:)
+    where.not(id: exclude.id).order(Arel.sql("RANDOM()")).limit(count)
+  end
 end

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -26,20 +26,7 @@
   <%= simple_format @article.content %>
 </div>
 
-<div class="mt-10">
-  <p class="text-xs font-medium uppercase text-center mx-auto text-gray-500">Share</p>
-  <div class="flex flex-row gap-4 justify-center items-center mt-4">
-    <%= link_to "#", class: "w-9 h-9 rounded-full grid place-items-center text-gray-500 hover:bg-neutral-200/50 bg-transparent border border-neutral-300 hover:border-neutral-300 " do %>
-      <%= lucide_icon("link-2", class: "h-5 w-5") %>
-    <% end %>
-    <%= link_to "#", class: "w-9 h-9 rounded-full grid place-items-center text-gray-500 hover:bg-neutral-200/50 bg-transparent border border-neutral-300 hover:border-neutral-300 " do %>
-      <%= lucide_icon("twitter", class: "h-5 w-5") %>
-    <% end %>
-    <%= link_to "#", class: "w-9 h-9 rounded-full grid place-items-center text-gray-500 hover:bg-neutral-200/50 bg-transparent border border-neutral-300 hover:border-neutral-300 " do %>
-      <%= lucide_icon("linkedin", class: "h-5 w-5") %>
-    <% end %>
-  </div>
-</div>
+<%= render "shared/social_share" %>
 
 <div class="grid grid-cols-[repeat(auto-fit,_minmax(min(288px,_100%),_1fr))] gap-4 mt-20">
   <%= render Article.random_sample(3, exclude: @article) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,7 +28,7 @@
       </div>
       <nav class="flex-1 text-sm text-center gap-x-1">
         <%= link_to "Articles", articles_path, class: "px-3 py-1.5 text-neutral-800 hover:text-neutral-900 hover:bg-neutral-200/60 rounded-xl" %>
-        <a href="#" class="px-3 py-1.5 text-neutral-800 hover:text-neutral-900 hover:bg-neutral-200/60 rounded-xl">Glossary</a>
+        <%= link_to "Glossary", terms_path, class: "px-3 py-1.5 text-neutral-800 hover:text-neutral-900 hover:bg-neutral-200/60 rounded-xl" %>
         <a href="https://github.com/maybe-finance/maybe" class="px-3 py-1.5 text-neutral-800 hover:text-neutral-9000 hover:bg-neutral-200/60 rounded-xl">Contribute</a>
       </nav>
       <div class="flex gap-x-2">
@@ -56,7 +56,7 @@
                 <%= link_to "Articles", articles_path %>
               </li>
               <li>
-                <%= link_to "Glossary", "#" %>
+                <%= link_to "Glossary", terms_path %>
               </li>
               <li>
                 <%= link_to "Contribute", "https://github.com/maybe-finance/maybe" %>

--- a/app/views/shared/_social_share.html.erb
+++ b/app/views/shared/_social_share.html.erb
@@ -1,0 +1,14 @@
+<div class="mt-10">
+  <p class="text-xs font-medium uppercase text-center mx-auto text-gray-500">Share</p>
+  <div class="flex flex-row gap-4 justify-center items-center mt-4">
+    <%= link_to "#", class: "w-9 h-9 rounded-full grid place-items-center text-gray-500 hover:bg-neutral-200/50 bg-transparent border border-neutral-300 hover:border-neutral-300 " do %>
+      <%= lucide_icon("link-2", class: "h-5 w-5") %>
+    <% end %>
+    <%= link_to "#", class: "w-9 h-9 rounded-full grid place-items-center text-gray-500 hover:bg-neutral-200/50 bg-transparent border border-neutral-300 hover:border-neutral-300 " do %>
+      <%= lucide_icon("twitter", class: "h-5 w-5") %>
+    <% end %>
+    <%= link_to "#", class: "w-9 h-9 rounded-full grid place-items-center text-gray-500 hover:bg-neutral-200/50 bg-transparent border border-neutral-300 hover:border-neutral-300 " do %>
+      <%= lucide_icon("linkedin", class: "h-5 w-5") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/terms/index.html.erb
+++ b/app/views/terms/index.html.erb
@@ -1,4 +1,46 @@
-<div>
-  <h1 class="font-bold text-4xl">Terms#index</h1>
-  <p>Find me in app/views/terms/index.html.erb</p>
+<div class="max-w-96 mx-auto text-center">
+  <div class="mb-1">
+    <div class="flex items-center justify-center gap-x-2">
+      <h1 class="text-3xl font-medium tracking-tight">Dictionary</h1>
+      <%= image_tag("icon-book.svg", alt: "", class: "inline") %>
+    </div>
+
+    <p class="text-sm text-neutral-400 mt-3">The A-Z of every finance, crypto or money related term you can possibly think of.</p>
+
+    <%= form_with method: :get, class: "mt-4 relative", data: { controller: "auto-submit-form", turbo_frame: "terms_list" } do |f| %>
+      <%= f.text_field:q, value: @query,
+        class: "w-full py-2.5 px-3 pl-10 bg-white border border-gray-300 shadow-xs rounded-xl text-sm",
+        placeholder: "Search for any term",
+        data: { auto_submit_form_target: "auto" } %>
+      <%= lucide_icon "search", class: "absolute top-2.5 left-3 w-5 h-5 text-gray-500 pointer-events-none" %>
+    <% end %>
+  </div>
 </div>
+
+<div class="flex gap-1 pt-7 sticky top-0 bg-[#f9f9f9]">
+  <% dict_groups.each do |group| %>
+    <a href="#<%= group.delete " " %>" class="grid place-items-center flex-1 py-2 px-1 text-sm font-medium text-gray-500 border border-transparent hover:bg-white hover:border hover:shadow-xs hover:text-neutral-900 target:bg-white rounded-xl"><%= group %></a>
+  <% end %>
+</div>
+
+<turbo-frame id="terms_list" target="_top">
+  <div class="hidden only:block max-w-96 mx-auto text-center py-56">
+    <%= lucide_icon "search-x", class: "w-6 h-6 mx-auto text-gray-500" %>
+    <p class="mt-4 text-sm font-medium">No results found</p>
+    <p class="mt-2 text-sm text-gray-500">We didn't find "<%= @query %>".</p>
+  </div>
+
+  <% @terms.group_by { |t| dict_group(t.title) }.each do |group, terms| %>
+    <div class="border-b last:border-b-0 py-12" id="<%= group.delete " " %>">
+      <h2 class="text-2xl font-medium tracking-tight px-2"><%= group %></h2>
+
+      <div class="columns-4 gap-4 space-y-1 mt-6">
+        <% terms.each do |term| %>
+          <%= link_to term.title, term_path(term), class: "block p-2 hover:bg-[#ececec] rounded-lg" %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+</turbo-frame>
+
+<%= render "shared/cta_waitlist" %>

--- a/app/views/terms/index.html.erb
+++ b/app/views/terms/index.html.erb
@@ -1,46 +1,53 @@
-<div class="max-w-96 mx-auto text-center">
-  <div class="mb-1">
-    <div class="flex items-center justify-center gap-x-2">
-      <h1 class="text-3xl font-medium tracking-tight">Dictionary</h1>
-      <%= image_tag("icon-book.svg", alt: "", class: "inline") %>
+<div data-controller="section-links" data-section-links-active-class="bg-white border-gray-100 shadow-xs text-neutral-900">
+  <div class="max-w-96 mx-auto text-center">
+    <div class="mb-1">
+      <div class="flex items-center justify-center gap-x-2">
+        <h1 class="text-3xl font-medium tracking-tight">Dictionary</h1>
+        <%= image_tag("icon-book.svg", alt: "", class: "inline") %>
+      </div>
+
+      <p class="text-sm text-neutral-400 mt-3">The A-Z of every finance, crypto or money related term you can possibly think of.</p>
+
+      <%= form_with method: :get, class: "mt-4 relative", data: { controller: "auto-submit-form", turbo_frame: "terms_list" } do |f| %>
+        <%= f.text_field:q, value: @query,
+          class: "w-full py-2.5 px-3 pl-10 bg-white border border-gray-300 shadow-xs rounded-xl text-sm",
+          placeholder: "Search for any term",
+          data: { auto_submit_form_target: "auto" } %>
+        <%= lucide_icon "search", class: "absolute top-2.5 left-3 w-5 h-5 text-gray-500 pointer-events-none" %>
+      <% end %>
     </div>
+  </div>
 
-    <p class="text-sm text-neutral-400 mt-3">The A-Z of every finance, crypto or money related term you can possibly think of.</p>
-
-    <%= form_with method: :get, class: "mt-4 relative", data: { controller: "auto-submit-form", turbo_frame: "terms_list" } do |f| %>
-      <%= f.text_field:q, value: @query,
-        class: "w-full py-2.5 px-3 pl-10 bg-white border border-gray-300 shadow-xs rounded-xl text-sm",
-        placeholder: "Search for any term",
-        data: { auto_submit_form_target: "auto" } %>
-      <%= lucide_icon "search", class: "absolute top-2.5 left-3 w-5 h-5 text-gray-500 pointer-events-none" %>
+  <div class="flex gap-1 pt-7 sticky top-0 bg-[#f9f9f9]">
+    <% dict_groups.each do |group| %>
+      <a
+        href="#<%= group.delete " " %>"
+        class="grid place-items-center flex-1 py-2 px-1 text-sm font-medium text-gray-500 border border-transparent hover:bg-white hover:border-gray-100 hover:shadow-xs hover:text-neutral-900 target:bg-white rounded-xl"
+        data-section-links-target="link">
+        <%= group %>
+      </a>
     <% end %>
   </div>
-</div>
 
-<div class="flex gap-1 pt-7 sticky top-0 bg-[#f9f9f9]">
-  <% dict_groups.each do |group| %>
-    <a href="#<%= group.delete " " %>" class="grid place-items-center flex-1 py-2 px-1 text-sm font-medium text-gray-500 border border-transparent hover:bg-white hover:border hover:shadow-xs hover:text-neutral-900 target:bg-white rounded-xl"><%= group %></a>
-  <% end %>
-</div>
-
-<turbo-frame id="terms_list" target="_top">
-  <div class="hidden only:block max-w-96 mx-auto text-center py-56">
-    <%= lucide_icon "search-x", class: "w-6 h-6 mx-auto text-gray-500" %>
-    <p class="mt-4 text-sm font-medium">No results found</p>
-    <p class="mt-2 text-sm text-gray-500">We didn't find "<%= @query %>".</p>
-  </div>
-
-  <% @terms.group_by { |t| dict_group(t.title) }.each do |group, terms| %>
-    <div class="border-b last:border-b-0 py-12" id="<%= group.delete " " %>">
-      <h2 class="text-2xl font-medium tracking-tight px-2"><%= group %></h2>
-
-      <div class="columns-4 gap-4 space-y-1 mt-6">
-        <% terms.each do |term| %>
-          <%= link_to term.title, term_path(term), class: "block p-2 hover:bg-[#ececec] rounded-lg" %>
-        <% end %>
-      </div>
+  <turbo-frame id="terms_list" target="_top">
+    <div class="hidden only:block max-w-96 mx-auto text-center py-56">
+      <%= lucide_icon "search-x", class: "w-6 h-6 mx-auto text-gray-500" %>
+      <p class="mt-4 text-sm font-medium">No results found</p>
+      <p class="mt-2 text-sm text-gray-500">We didn't find "<%= @query %>".</p>
     </div>
-  <% end %>
-</turbo-frame>
 
-<%= render "shared/cta_waitlist" %>
+    <% @terms.group_by { |t| dict_group(t.title) }.each do |group, terms| %>
+      <div id="<%= group.delete " " %>" class="border-b last:border-b-0 py-12 scroll-mt-10" data-section-links-target="section">
+        <h2 class="text-2xl font-medium tracking-tight px-2"><%= group %></h2>
+
+        <div class="columns-4 gap-4 space-y-1 mt-6">
+          <% terms.each do |term| %>
+            <%= link_to term.title, term_path(term), class: "block p-2 hover:bg-[#ececec] rounded-lg" %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </turbo-frame>
+
+  <%= render "shared/cta_waitlist" %>
+</div>

--- a/app/views/terms/show.html.erb
+++ b/app/views/terms/show.html.erb
@@ -1,4 +1,31 @@
-<div>
-  <h1 class="font-bold text-4xl">Terms#show</h1>
-  <p>Find me in app/views/terms/show.html.erb</p>
+<%= link_to terms_path, class: "w-9 h-9 rounded-full grid place-items-center mx-auto text-gray-500 hover:bg-neutral-200/50 bg-transparent border border-neutral-300 hover:border-neutral-300 " do %>
+  <%= lucide_icon("arrow-left", class: "h-5 w-5") %>
+<% end %>
+
+<div class="max-w-[520px] mt-4 mx-auto prose">
+  <p class="text-sm text-center">
+    <span class="text-gray-500">Dictionary / <%= dict_group(@term.title) %> /</span> <%= @term.title %>
+  </p>
+
+  <%= simple_format @term.content %>
 </div>
+
+<%= render "shared/social_share" %>
+
+<div class="bg-white p-4 border shadow-xs rounded-2xl mt-10 max-w-[594px] mx-auto">
+  <div class="rounded-lg grid place-items-center w-10 h-10 bg-[#f5f9ff] border border-[#eef2f8]">
+    <%= lucide_icon "bookmark", class: "h-6 w-6 text-blue-500" %>
+  </div>
+  <h2 class="font-medium text-lg mt-3">Discover more terms</h2>
+
+  <div class="grid grid-cols-2 gap-x-3 gap-y-[6px] mt-3">
+    <% Term.random_sample(6, exclude: @term).each do |term| %>
+      <%= link_to term_path(term), class: "flex flex-row items-center py-2.5 px-3 bg-neutral-100/50 hover:bg-neutral-200/50 rounded-lg" do %>
+        <span><%= term.title %></span>
+        <%= lucide_icon "chevron-right", class: "h-5 w-5 ml-auto text-gray-500" %>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+
+<%= render "shared/cta_waitlist" %>


### PR DESCRIPTION
/claim #11 
Resolves #11 

This PR builds out the Terms feature of the website.

- [x] Match design elements
- [x]  Group terms correctly (via letters)
- [x]  "Discover more terms" section with randomly selected terms
- [x]  The "Join waitlist" form should use the existing render_signup_form
- [x]  Fixed term subheader when scrolling on the index page
- [x]  Search results page
- [x]  Empty search state

https://github.com/maybe-finance/marketing/assets/1793797/31983e1b-a31b-4f62-8feb-f8fc9385991b

