### PR TITLE
Fix terms grid area

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -74,10 +74,10 @@
         </ul>
       </div>
     </header>
-    <main class="max-w-5xl px-3 mx-auto my-10 md:px-0">
+    <main class="max-w-5xl px-3 mx-auto my-10 md:px-4">
       <%= yield %>
     </main>
-    <footer class="max-w-5xl p-6 mx-auto my-8 md:p-0">
+    <footer class="max-w-5xl p-6 mx-auto my-8 md:p-4">
       <div class="flex flex-col justify-between gap-x-4 md:flex-row">
         <div class="flex flex-col gap-y-4 max-w-96">
           <div><%= link_to image_tag("icon-logo.svg", alt: "Maybe Logo", class: "w-10 inline"), root_path %></div>

--- a/app/views/terms/index.html.erb
+++ b/app/views/terms/index.html.erb
@@ -45,7 +45,7 @@
       <div id="<%= group.delete " " %>" class="py-12 border-b last:border-b-0 scroll-mt-10" data-section-links-target="section">
         <h2 class="px-2 text-2xl font-medium tracking-tight"><%= group %></h2>
 
-        <div class="gap-4 mt-6 space-y-1 columns-2 md:columns-4">
+        <div class="grid gap-1 mt-6 grid-cols-2 md:grid-cols-4">
           <% terms.each do |term| %>
             <%= link_to term.name, term_path(term), class: "block p-2 hover:bg-alpha-black-50 rounded-lg" %>
           <% end %>


### PR DESCRIPTION
- Change terms area to use grid
- Remove space that was causing elements to overflow
- Change reading from left-to-right
- Add padding to main and footer on non-mobile screens

https://github.com/maybe-finance/marketing/assets/1866816/85a8f290-da3a-4e8b-bc81-3f8f99fc0a8a

