### PR TITLE
Fix numeric fields

### DIFF
--- a/app/helpers/application_form_builder.rb
+++ b/app/helpers/application_form_builder.rb
@@ -35,7 +35,7 @@ class ApplicationFormBuilder < ActionView::Helpers::FormBuilder
       label(method, *label_args(options)) +
       @template.tag.div(class: "flex items-center") do
         @template.tag.span(options[:unit_symbol], class: "pl-3 pb-2 pt-1 text-sm text-gray-500") +
-        number_field(method, merged_options.except(:label))
+        text_field(method, merged_options.except(:label))
       end
     end
   end

--- a/app/views/tools/_roi_calculator.html.erb
+++ b/app/views/tools/_roi_calculator.html.erb
@@ -6,15 +6,15 @@
 <div class="flex p-2 bg-white border shadow-xs rounded-xl" data-controller="roi-calculator">
   <%= form_with html: { class: "bg-gray-25 p-4 rounded-lg w-1/3 flex flex-col gap-4", data: { action: "submit->roi-calculator#calculate" }} do |form| %>
     <div class="flex flex-col gap-2">
-      <%= form.unit_field :amount_invested, label: "Amount Invested", value: 0, unit_symbol: "$"  %>
+      <%= form.unit_field :amount_invested, label: "Amount Invested", value: 0, unit_symbol: "$", data: { controller: "autonumeric" }  %>
     </div>
 
     <div class="flex flex-col gap-2">
-      <%= form.unit_field :amount_returned, label: "Amount Returned", value: 0, unit_symbol: "$" %>
+      <%= form.unit_field :amount_returned, label: "Amount Returned", value: 0, unit_symbol: "$", data: { controller: "autonumeric" } %>
     </div>
 
     <div class="flex form-field">
-      <%= form.unit_field :investment_length, label: "Investment Length", value: 0, outer_div_class: "border-0 shadow-none focus-within:border-transparent focus-within:ring-0 focus-within:ring-transparent"  %>
+      <%= form.unit_field :investment_length, label: "Investment Length", value: 0, data: { controller: "autonumeric" }, outer_div_class: "border-0 shadow-none focus-within:border-transparent focus-within:ring-0 focus-within:ring-transparent"  %>
       <%= render partial: "shared/period_select", locals: { value: "years" } %>
     </div>
 


### PR DESCRIPTION
The unit_field should be a text_field combined with the autonumeric controller. This ensures appropriate formatting of the unit.

Autonumeric doesn't work with fields of the type 'number' since they include characters like the comma.

This also fixes the sliders on the Financial Freedom Calculator since they expect fields that have the autonumeric controller to work.