### PR TITLE
Fix stock ranking in portfolio backtest

### DIFF
--- a/app/javascript/controllers/search_select_controller.js
+++ b/app/javascript/controllers/search_select_controller.js
@@ -166,7 +166,7 @@ export default class extends Controller {
     const dataList = this.listValue
     let filteredList;
 
-    if (this.hasCustomFilterValue && typeof window[this.customFilterValue] === 'function') {
+    if (typeof window[this.customFilterValue] === 'function') {
       filteredList = window[this.customFilterValue](dataList, filterValue).slice(0, 5);
     } else {
       filteredList = dataList

--- a/app/views/shared/_search_select.erb
+++ b/app/views/shared/_search_select.erb
@@ -1,4 +1,4 @@
-<div class="relative flex self-end gap-2 w-full" data-controller="search-select" data-search-select-active-class="bg-gray-100" data-search-select-list-value="<%= list %>">
+<div class="relative flex self-end gap-2 w-full" data-controller="search-select" data-search-select-active-class="bg-gray-100" data-search-select-list-value="<%= list %>" <%= "data-search-select-custom-filter-value=#{local_assigns[:custom_filter_value]}" if local_assigns[:custom_filter_value].present? %>>
   <%= tag.input type: :hidden, name: name,
         disabled: local_assigns[:disabled],
         data: { search_select_target: "hiddenInput", auto_submit_form_target: "auto" } %>

--- a/app/views/shared/_stocks_allocator.html.erb
+++ b/app/views/shared/_stocks_allocator.html.erb
@@ -1,11 +1,12 @@
-<%= tag.div class: [ "flex items-center gap-2", { "hidden": !index.zero? } ], data: { stocks_allocator_target: "allocation", search_select_custom_filter_value: "prioritizeTickerFilter" } do %>
+<%= tag.div class: [ "flex items-center gap-2", { "hidden": !index.zero? } ], data: { stocks_allocator_target: "allocation" } do %>
   <%= render partial: "shared/search_select", locals: {
         list: local_assigns[:list],
         label: local_assigns[:label],
         name: "stocks[]",
         required: local_assigns[:required],
         disabled: !local_assigns[:required],
-        placeholder: "Search for a stock"
+        placeholder: "Search for a stock",
+        custom_filter_value: "prioritizeTickerFilter"
       } %>
 
   <div class="relative w-16">
@@ -31,20 +32,30 @@
 
 <script>
 window.prioritizeTickerFilter = function(dataList, filterValue) {
+  function getStockSearchRank(item) {
+    const filterWord = filterValue.toLowerCase()
+    const ticker = item.name.toLowerCase().match(/\((.*?)\)/)?.[1];
+    const name = item.name.toLowerCase();
+
+    let rank = 0;
+
+    if (ticker?.startsWith(filterWord)) {
+      rank += (2 ** filterWord.length)
+    }
+
+    let i = 0
+    while ((i = name.indexOf(filterWord, i)) >= 0) {
+      rank += (1.2 ** filterWord.length)
+      i += 1
+    }
+
+    return rank
+  }
+
   return dataList
-    .filter(item => {
-      const ticker = item.name.match(/\((.*?)\)/)?.[1] || '';
-      return ticker.toLowerCase().includes(filterValue) ||
-             item.name.toLowerCase().includes(filterValue);
-    })
-    .sort((a, b) => {
-      const tickerA = a.name.match(/\((.*?)\)/)?.[1] || '';
-      const tickerB = b.name.match(/\((.*?)\)/)?.[1] || '';
-      const aStartsWithFilter = tickerA.toLowerCase().startsWith(filterValue);
-      const bStartsWithFilter = tickerB.toLowerCase().startsWith(filterValue);
-      if (aStartsWithFilter && !bStartsWithFilter) return -1;
-      if (!aStartsWithFilter && bStartsWithFilter) return 1;
-      return 0;
-    });
+    .map(item => ({ item, rank: getStockSearchRank(item) }))
+    .filter(itemWithRank => itemWithRank.rank > 0)
+    .sort((a, b) => b.rank - a.rank)
+    .map(itemWithRank => itemWithRank.item);
 };
 </script>


### PR DESCRIPTION
Fix use of custom filter value in Stock Portfolio Backtest.
Sort stocks by ranking them :
 - by ticker with a highier coefficient
 - by global text matching otherwise. Word repetition improve the ranking furthermore

/claim https://github.com/maybe-finance/marketing/issues/178
/closes https://github.com/maybe-finance/marketing/issues/178
#Fixes https://github.com/maybe-finance/marketing/issues/178