### PR TITLE
Fix Stored cross-site scripting

### DIFF
--- a/app/views/terms/show.html.erb
+++ b/app/views/terms/show.html.erb
@@ -1,4 +1,5 @@
 <%
+  include ERB::Util
   title "#{@term.title} - Financial Terms"
   description "#{markdown(@term.content).gsub(%r{</?[^>]+?>}, '')[0...300]}..."
   meta_image @term.meta_image_url if @term.meta_image_url.present?
@@ -16,7 +17,7 @@
         "@type": "WebPage",
         "@id": request.original_url
       },
-      "headline": @term.name.presence || "#{@term.name} meaning in personal finance",
+      "headline": html_escape(@term.name.presence || "#{@term.name} meaning in personal finance"),
       "description": article_description,
       "author": {
         "@type": "Organization",
@@ -61,13 +62,13 @@
     # If there's only one schema, output it directly.
     # If there are multiple (e.g., Article and VideoObject), output them as a graph.
     if schemas.size == 1
-      concat(tag.script(schemas.first.to_json.html_safe, type: "application/ld+json"))
+      concat(tag.script(schemas.first.to_json, type: "application/ld+json"))
     elsif schemas.size > 1
       graph_schema = {
         "@context": "https://schema.org",
         "@graph": schemas
       }
-      concat(tag.script(graph_schema.to_json.html_safe, type: "application/ld+json"))
+      concat(tag.script(graph_schema.to_json, type: "application/ld+json"))
     end
   end
 %>


### PR DESCRIPTION
https://github.com/maybe-finance/marketing/blob/47d75456c988dee327842a36b0efdfdb3923af3f/app/views/terms/show.html.erb#L19-L19

https://github.com/maybe-finance/marketing/blob/47d75456c988dee327842a36b0efdfdb3923af3f/app/views/terms/show.html.erb#L64-L64

https://github.com/maybe-finance/marketing/blob/47d75456c988dee327842a36b0efdfdb3923af3f/app/views/terms/show.html.erb#L70-L70


Fix the stored cross-site scripting vulnerability, we need to ensure that all potentially tainted data is properly escaped before being used in the JSON output. Rails provides the `html_escape` method to escape strings safely. Instead of using `.html_safe` directly, we should sanitize the data before converting it to JSON.

The best approach is to sanitize the values in the `article_schema` and `video_schema` hashes before calling `.to_json`. This ensures that all data embedded in the `<script>` tag is safe. Additionally, we should avoid using `.html_safe` unless absolutely necessary.



