### PR TITLE
Set reasonable default values for all financial calculators

### DIFF
--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -27,7 +27,7 @@ class TermsController < ApplicationController
   #   GET /terms/ruby-on-rails
   def show
     @term = Term.find_by(slug: params[:id])
-    
+
     if @term.nil?
       redirect_to terms_path, alert: "The financial term you're looking for could not be found."
     end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -28,7 +28,7 @@ class Article < ApplicationRecord
   end
 
   def self.ransackable_attributes(auth_object = nil)
-    ["author_name", "content", "created_at", "id", "meta_image_url", "publish_at", "slug", "title", "updated_at"]
+    [ "author_name", "content", "created_at", "id", "meta_image_url", "publish_at", "slug", "title", "updated_at" ]
   end
 
   private

--- a/app/presenters/tool/presenter/bogleheads_growth_calculator.rb
+++ b/app/presenters/tool/presenter/bogleheads_growth_calculator.rb
@@ -1,5 +1,5 @@
 class Tool::Presenter::BogleheadsGrowthCalculator < Tool::Presenter
-  attribute :invested_amount, :tool_float, default: 0.0
+  attribute :invested_amount, :tool_float, default: 10000.0
 
   attribute :stock_market_percentage, :tool_percentage, default: 40.0
   attribute :international_stock_market_percentage, :tool_percentage, default: 30.0

--- a/app/presenters/tool/presenter/compound_interest_calculator.rb
+++ b/app/presenters/tool/presenter/compound_interest_calculator.rb
@@ -1,9 +1,9 @@
 class Tool::Presenter::CompoundInterestCalculator < Tool::Presenter
-  attribute :annual_interest_rate, :tool_percentage, default: 0.0
+  attribute :annual_interest_rate, :tool_percentage, default: 7.0
 
-  attribute :initial_investment, :tool_float, default: 0.0
-  attribute :monthly_contribution, :tool_float, default: 0.0
-  attribute :years_to_grow, :tool_float, default: 0.0, min: 0.0, max: 150.0
+  attribute :initial_investment, :tool_float, default: 5000.0
+  attribute :monthly_contribution, :tool_float, default: 500.0
+  attribute :years_to_grow, :tool_float, default: 20.0, min: 0.0, max: 150.0
   attribute :filter, :string
 
   def blank?

--- a/app/presenters/tool/presenter/early_mortgage_payoff_calculator.rb
+++ b/app/presenters/tool/presenter/early_mortgage_payoff_calculator.rb
@@ -2,7 +2,7 @@ class Tool::Presenter::EarlyMortgagePayoffCalculator < Tool::Presenter
   attribute :loan_amount, :tool_float, default: 500_000, min: 0.0, max: 1_000_000.0
   attribute :extra_payment, :tool_float, default: 500.0
 
-  attribute :interest_rate, :tool_percentage, default: 0.0
+  attribute :interest_rate, :tool_percentage, default: 6.5
   attribute :savings_rate, :tool_percentage, default: 4.0
 
   attribute :original_term, :tool_integer, default: 30

--- a/app/presenters/tool/presenter/financial_freedom_calculator.rb
+++ b/app/presenters/tool/presenter/financial_freedom_calculator.rb
@@ -1,8 +1,8 @@
 class Tool::Presenter::FinancialFreedomCalculator < Tool::Presenter
-  attribute :annual_savings_growth_rate, :tool_percentage, default: 0.0
+  attribute :annual_savings_growth_rate, :tool_percentage, default: 7.0
 
-  attribute :current_savings, :tool_float, default: 0.0
-  attribute :monthly_expenses, :tool_float, default: 0.0
+  attribute :current_savings, :tool_float, default: 50000.0
+  attribute :monthly_expenses, :tool_float, default: 4000.0
 
   def blank?
     [ current_savings, monthly_expenses, annual_savings_growth_rate ].all?(&:zero?)

--- a/app/presenters/tool/presenter/home_affordability_calculator.rb
+++ b/app/presenters/tool/presenter/home_affordability_calculator.rb
@@ -1,13 +1,13 @@
 class Tool::Presenter::HomeAffordabilityCalculator < Tool::Presenter
-  attribute :loan_duration, :tool_integer, default: 0.0
+  attribute :loan_duration, :tool_integer, default: 30
 
-  attribute :loan_interest_rate, :tool_percentage, default: 0.0
+  attribute :loan_interest_rate, :tool_percentage, default: 6.5
 
-  attribute :desired_home_price, :tool_float, default: 0.0
-  attribute :down_payment, :tool_float, default: 0.0
-  attribute :annual_pre_tax_income, :tool_float, default: 0.0
-  attribute :monthly_debt_payments, :tool_float, default: 0.0
-  attribute :hoa_plus_pmi, :tool_float, default: 0.0
+  attribute :desired_home_price, :tool_float, default: 400000.0
+  attribute :down_payment, :tool_float, default: 80000.0
+  attribute :annual_pre_tax_income, :tool_float, default: 100000.0
+  attribute :monthly_debt_payments, :tool_float, default: 500.0
+  attribute :hoa_plus_pmi, :tool_float, default: 300.0
 
   def blank?
     [ desired_home_price, down_payment, annual_pre_tax_income, loan_interest_rate, monthly_debt_payments ].all?(&:zero?)

--- a/app/presenters/tool/presenter/inflation_calculator.rb
+++ b/app/presenters/tool/presenter/inflation_calculator.rb
@@ -1,8 +1,8 @@
 class Tool::Presenter::InflationCalculator < Tool::Presenter
   attribute :inflation_percentage, :tool_percentage, default: 3.0
 
-  attribute :initial_amount, :tool_float, default: 0.0
-  attribute :years, :tool_float, default: 0.0
+  attribute :initial_amount, :tool_float, default: 1000.0
+  attribute :years, :tool_float, default: 10.0
 
   def blank?
     [ initial_amount, years ].all?(&:zero?)

--- a/app/presenters/tool/presenter/loan_calculator.rb
+++ b/app/presenters/tool/presenter/loan_calculator.rb
@@ -1,7 +1,7 @@
 class Tool::Presenter::LoanCalculator < Tool::Presenter
-  attribute :loan_amount, :tool_float, default: 0.0
-  attribute :interest_rate, :tool_percentage, default: 0.0
-  attribute :loan_term, :tool_integer, default: 0
+  attribute :loan_amount, :tool_float, default: 25000.0
+  attribute :interest_rate, :tool_percentage, default: 5.5
+  attribute :loan_term, :tool_integer, default: 5
   attribute :loan_period, :tool_enum, enum: %w[ years months ], default: "years"
   attribute :date, :date, default: -> { Date.today }
 

--- a/app/presenters/tool/presenter/retirement_calculator.rb
+++ b/app/presenters/tool/presenter/retirement_calculator.rb
@@ -1,15 +1,15 @@
 class Tool::Presenter::RetirementCalculator < Tool::Presenter
   attribute :retirement_age, :tool_integer, default: 65, max: 100
-  attribute :current_age, :tool_integer, default: 0, min: 0
+  attribute :current_age, :tool_integer, default: 30, min: 0
 
-  attribute :annual_salary, :tool_float, default: 0.0
-  attribute :current_401k_balance, :tool_float, default: 0.0
+  attribute :annual_salary, :tool_float, default: 75000.0
+  attribute :current_401k_balance, :tool_float, default: 25000.0
 
   attribute :annual_rate_of_return, :tool_percentage, default: 5.0
-  attribute :monthly_contribution, :tool_percentage, default: 0.0
-  attribute :annual_salary_increase, :tool_percentage, default: 0.0
-  attribute :employer_match, :tool_percentage, default: 0.0
-  attribute :salary_limit_match, :tool_percentage, default: 0.0
+  attribute :monthly_contribution, :tool_percentage, default: 6.0
+  attribute :annual_salary_increase, :tool_percentage, default: 3.0
+  attribute :employer_match, :tool_percentage, default: 50.0
+  attribute :salary_limit_match, :tool_percentage, default: 6.0
 
   def blank?
     [ annual_salary, monthly_contribution, annual_salary_increase,

--- a/app/presenters/tool/presenter/roi_calculator.rb
+++ b/app/presenters/tool/presenter/roi_calculator.rb
@@ -1,7 +1,7 @@
 class Tool::Presenter::RoiCalculator < Tool::Presenter
-  attribute :amount_invested, :tool_float, default: 0.0
-  attribute :amount_returned, :tool_float, default: 0.0
-  attribute :investment_length, :tool_float, default: 0.0
+  attribute :amount_invested, :tool_float, default: 10000.0
+  attribute :amount_returned, :tool_float, default: 12500.0
+  attribute :investment_length, :tool_float, default: 3.0
 
   attribute :investment_period, :tool_enum, enum: %w[ years weeks days ], default: "years"
 

--- a/app/presenters/tool/presenter/stock_portfolio_backtest.rb
+++ b/app/presenters/tool/presenter/stock_portfolio_backtest.rb
@@ -1,13 +1,13 @@
 class Tool::Presenter::StockPortfolioBacktest < Tool::Presenter
-  attribute :benchmark_stock, :string
+  attribute :benchmark_stock, :string, default: "SPY"
 
   attribute :investment_amount, :tool_float, default: 10_000.0
 
-  attribute :start_date, :date
+  attribute :start_date, :date, default: -> { 1.year.ago }
   attribute :end_date, :date, default: -> { Date.today }
 
-  attribute :stocks, :tool_array, type: :string, default: [], max: 10
-  attribute :stock_allocations, :tool_array, type: :percentage, default: [], max: 10
+  attribute :stocks, :tool_array, type: :string, default: [ "AAPL", "MSFT", "GOOGL" ], max: 10
+  attribute :stock_allocations, :tool_array, type: :percentage, default: [ 0.34, 0.33, 0.33 ], max: 10
 
   def blank?
     [ benchmark_stock, start_date ].all?(&:blank?)


### PR DESCRIPTION
Updated all 11 financial calculator presenters with sensible defaults to improve user experience:

- Bogleheads Growth Calculator: $10,000 initial investment
- Early Mortgage Payoff Calculator: 6.5% interest rate
- Financial Freedom Calculator: $50,000 savings, $4,000 monthly expenses, 7% growth rate
- Home Affordability Calculator: $400,000 home price, $80,000 down payment, $100,000 income, 6.5% rate, 30-year loan
- Inflation Calculator: $1,000 initial amount, 10 years
- Loan Calculator: $25,000 loan amount, 5.5% interest rate, 5-year term
- Retirement Calculator: Age 30, $75,000 salary, $25,000 current balance, 6% contribution, 3% salary increase, 50% employer match on 6%
- ROI Calculator: $10,000 invested, $12,500 returned, 3 years
- Stock Portfolio Backtest: SPY benchmark, 1 year lookback, AAPL/MSFT/GOOGL portfolio with equal allocation
- Compound Interest Calculator: $5,000 initial, $500 monthly contribution, 7% annual rate, 20 years

These defaults allow users to quickly try out each calculator without having to fill in all fields from zero, providing a better first-time user experience.

🤖 Generated with [Claude Code](https://claude.ai/code)